### PR TITLE
docs: add benchmark test

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,23 @@ Unit testing can be run in isolation through the command:
 $ docker-compose run --rm app npm run test:scripts
 ```
 
+### Benchmarking
+
+Although not part of the CI test suite, a _Benchmark_ test is available to see how _Queue_ performs
+against a standard array with 1,000,000 items.
+
+The _Benchmark_ test can be run with the following command:
+
+```sh
+$ docker-compose run --rm app npm run test:benchmark
+```
+
+Optionally, the amount of items can be set by passing in the amount to the script:
+
+```sh
+$ docker-compose run --rm app npm run test:benchmark 65535
+```
+
 ## Contributing
 
 Contributions are always welcome, just submit a PR to get the conversation going. Please make sure

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const Benchmark = require('benchmark');
 
+// eslint-disable-next-line import/no-unresolved
 const Queue = require('../lib/index').default;
 
 const suite = new Benchmark.Suite();

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,0 +1,42 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+const Benchmark = require('benchmark');
+
+const Queue = require('../lib/index').default;
+
+const suite = new Benchmark.Suite();
+
+const testLength = process.argv[2] || 1000000;
+const queue = new Queue(testLength);
+const array = new Array(testLength);
+
+for (let length = 0; length < testLength; length += 1) {
+  queue.enqueue(length);
+  array.push(length);
+}
+
+process.stdout.write(`\nRunning benchmark with ${testLength} items:\n\n`);
+
+suite
+  .add('Array#shift()   ', () => {
+    const a = array.shift();
+    const b = array.shift();
+    const c = array.shift();
+    array.push(a);
+    array.push(b);
+    array.push(c);
+  })
+  .add('Queue#dequeue() ', () => {
+    const a = queue.dequeue();
+    const b = queue.dequeue();
+    const c = queue.dequeue();
+    queue.enqueue(a);
+    queue.enqueue(b);
+    queue.enqueue(c);
+  })
+  .on('cycle', (event) => {
+    process.stdout.write(`${String(event.target)}\n`);
+  })
+  .on('complete', function complete() {
+    process.stdout.write(`Fastest is ${this.filter('fastest').map('name')}\n`);
+  })
+  .run({ async: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2078,6 +2078,16 @@
       "integrity": "sha512-wI3QtdLppHNkmM1VgRVLCrlWCKk/YexlPicYbXPs4eYdd1InrUCTFsx5bX1iUQzzMsoRXXPpM1r+p7JEJJydag==",
       "dev": true
     },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "binary-extensions": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
@@ -3975,8 +3985,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3997,14 +4006,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4019,20 +4026,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4149,8 +4153,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4162,7 +4165,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4177,7 +4179,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4185,14 +4186,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4211,7 +4210,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4292,8 +4290,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4305,7 +4302,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4391,8 +4387,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4428,7 +4423,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4448,7 +4442,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4492,14 +4485,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -11289,6 +11280,12 @@
           }
         }
       }
+    },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
+      "dev": true
     },
     "please-upgrade-node": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "version": "0.0.0-development",
   "description": "A JavaScript implementation of the Queue data structure",
   "main": "lib/index.js",
-  "files": ["/lib"],
+  "files": [
+    "/lib"
+  ],
   "scripts": {
     "build": "babel src --out-dir lib --ignore src/**/*.test.js",
     "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls",
     "semantic-release": "semantic-release",
     "test": "npm run test:lint && npm run test:vulnerabilities && npm run test:scripts",
+    "test:benchmark": "npm run build && node benchmark/index.js",
     "test:lint": "eslint --ext js .",
     "test:scripts": "jest --config ./jest.config.json --coverage",
     "test:vulnerabilities": "npm audit",
@@ -28,6 +31,7 @@
     "@commitlint/config-conventional": "^7.1.2",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
+    "benchmark": "^2.1.4",
     "coveralls": "^3.0.2",
     "eslint": "^5.9.0",
     "eslint-config-airbnb-base": "^13.1.0",


### PR DESCRIPTION
add benchmark test using `benchmark` npm package (https://www.npmjs.com/package/benchmark)
standard test uses 1,000,000 items
item count can be altered though the first command-line argument